### PR TITLE
Partial updates for ubuntu 20.04

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,8 @@ Depends: ${misc:Depends},
  gir1.2-gtk-3.0,
  gir1.2-glib-2.0,
  gir1.2-gdkpixbuf-2.0,
- gir1.2-webkit-3.0
+ gir1.2-webkit2-4.0
+ gir1.2-gexiv2-0.10
 Description: Ojo Image Viewer
  A fast and good-looking image viewer, nice as a preliminary stage in a
  photography workflow

--- a/ojo/ojo.py
+++ b/ojo/ojo.py
@@ -20,7 +20,7 @@ import gi  # isort:skip
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gdk", "3.0")
 gi.require_version("GdkPixbuf", "2.0")
-gi.require_version("WebKit", "3.0")
+gi.require_version("WebKit2", "4.0")
 gi.require_version("GExiv2", "0.10")
 from gi.repository import Gdk, GdkPixbuf, GObject, Gtk  # isort:skip
 # fmt: on

--- a/ojo/webview.py
+++ b/ojo/webview.py
@@ -1,4 +1,4 @@
-from gi.repository import WebKit, GObject
+from gi.repository import WebKit2, GObject
 
 import logging
 from ojo import util
@@ -47,9 +47,9 @@ class WebView:
         with open(ojoconfig.get_data_file(html_filename)) as f:
             html = f.read()
 
-        self.web_view = WebKit.WebView()
-        self.web_view.set_transparent(True)
-        self.web_view.set_can_focus(True)
+        self.web_view = WebKit2.WebView()
+        self.web_view.set_transparent(True) # broken
+        self.web_view.set_can_focus(True) # broken
 
         def nav(wv, command):
             logging.debug("Received command: " + command)
@@ -61,14 +61,14 @@ class WebView:
                     argument = command[index + 1 :]
                     on_action_fn(action, argument)
 
-        self.web_view.connect("status-bar-text-changed", nav)
+        self.web_view.connect("status-bar-text-changed", nav) # broken
 
         def _on_load(*args):
             self.is_loaded = True
             if on_load_fn:
                 on_load_fn()
 
-        self.web_view.connect("document-load-finished", _on_load)
+        self.web_view.connect("document-load-finished", _on_load) # broken
         self.web_view.load_string(
             html, "text/html", "UTF-8", util.path2url(ojoconfig.get_data_path()) + "/"
         )


### PR DESCRIPTION
Looks like [gir1.2-webkit-3.0](https://packages.ubuntu.com/bionic/gir1.2-webkit-3.0) on bionic (18.04) was updated to [gir1.2-webkit2-4.0](https://packages.ubuntu.com/focal/gir1.2-webkit2-4.0) on focal (20.04).

This PR is an initial attempt to apply those updates; however, a more involved rewrite is required to incorporate the [WebKit2 API](https://lazka.github.io/pgi-docs/WebKit2-4.0/classes/WebView.html). For example, there's no longer a `set_transparent` method or `"status-bar-text-changed"` signal.

I'm not going to be spending any more time on this update, but wanted to share some progress so far in case anyone else wants to continue effort.

I'm testing this by running `bin/ojo` as described in the [contributing instructions](https://github.com/peterlevi/ojo#run-from-code-and-contribute).